### PR TITLE
use GITHUB_OUTPUT file instead of set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ commit=$(git rev-parse HEAD)
 
 if [ "$tag_commit" == "$commit" ]; then
     echo "No new commits since previous tag. Skipping..."
-    echo ::set-output name=tag::$tag
+    echo "tag=$tag" >> $GITHUB_OUTPUT
     exit 0
 fi
 
@@ -109,16 +109,16 @@ fi
 echo $new
 
 # set outputs
-echo ::set-output name=new_tag::$new
-echo ::set-output name=part::$part
+echo "new_tag=$new" >> $GITHUB_OUTPUT
+echo "part=$part" >> $GITHUB_OUTPUT
 
 # use dry run to determine the next tag
 if $dryrun; then
-    echo ::set-output name=tag::$tag
+    echo "tag=$tag" >> $GITHUB_OUTPUT
     exit 0
 fi 
 
-echo ::set-output name=tag::$new
+echo "tag=$new" >> $GITHUB_OUTPUT
 
 if $pre_release; then
     echo "This branch is not a release branch. Skipping the tag creation."


### PR DESCRIPTION
* use GITHUB_OUTPUT file instead of set-output. Due to [deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
